### PR TITLE
fix: compensation

### DIFF
--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -25,10 +25,11 @@ export class AppService implements OnModuleInit, OnModuleDestroy {
 
   public async onModuleInit() {
     // example:
-    // await this.adapterService.loadLastBlockNumber(1376336, 1476336);
+    // await this.adapterService.loadLastBlockNumber(1476336, 1376336);
     // second params is utc+8
     // await this.holdLpPointService.handleHoldPoint(1395273, new Date(1715159940 * 1000).toISOString());
-
+    await this.adapterService.loadLastBlockNumber(1685534, 1629154)
+    await this.tvlPointService.handleHoldPoint(1685534, new Date(1715851196 * 1000).toISOString());
     this.startWorkers();
   }
 

--- a/src/points/adapter.service.ts
+++ b/src/points/adapter.service.ts
@@ -49,9 +49,9 @@ export class AdapterService extends Worker {
     // return this.runProcess();
   }
 
-  public async loadLastBlockNumber(lastBlockNumber?: number, curBlockNumber?: number) {
+  public async loadLastBlockNumber(curBlockNumber?: number, lastBlockNumber?: number) {
     if (lastBlockNumber && curBlockNumber) {
-      await this.runCommandsInAllDirectories(lastBlockNumber, curBlockNumber);
+      await this.runCommandsInAllDirectories(curBlockNumber, lastBlockNumber);
     } else {
       const lastBlock = await this.blockRepository.getLastBlock({
         select: { number: true, timestamp: true },
@@ -65,7 +65,7 @@ export class AdapterService extends Worker {
       }
       const adapterTxSyncBlockNumber = await this.cacheRepository.getValue(this.adapterTxSyncBlockNumber) ?? 0;
       await this.runCommandsInAllDirectories(lastBlock.number, Number(adapterTxSyncBlockNumber));
-      this.cacheRepository.setValue(this.adapterTxSyncBlockNumber, adapterTxSyncBlockNumber.toString())
+      this.cacheRepository.setValue(this.adapterTxSyncBlockNumber, lastBlock.number.toString())
     }
 
   }

--- a/src/points/tvlPoint.service.ts
+++ b/src/points/tvlPoint.service.ts
@@ -197,7 +197,7 @@ export class TvlPointService extends Worker {
   ): Promise<Map<string, BlockAddressTvl>> {
     // If the score for this block height already exists,
     // it should not be calculated again
-    const pointAddresses = await this.blockAddressPointOfLpRepository.getBlockAddressPointOfLpByBlock(blockNumber) //
+    const alreadyCalculatedPointsKey = await this.blockAddressPointOfLpRepository.getBlockAddressPointKeyByBlock(blockNumber)
 
     const addressTvlMap: Map<string, BlockAddressTvl> = new Map();
     const blockNumbers = [blockNumber];
@@ -212,7 +212,7 @@ export class TvlPointService extends Worker {
       if (balanceMap.has(key)) {
         balanceMap.get(key).push(balance);
       } else {
-        if (!pointAddresses.includes(address)) {
+        if (!alreadyCalculatedPointsKey.includes(key)) {
           balanceMap.set(key, [balance]);
         }
       }

--- a/src/points/tvlPoint.service.ts
+++ b/src/points/tvlPoint.service.ts
@@ -83,15 +83,10 @@ export class TvlPointService extends Worker {
     this.logger.log(`Early bird multiplier: ${earlyBirdMultiplier}`);
     const tokenPriceMap = await this.getTokenPriceMap(currentStatisticalBlock.number);
     const blockTs = currentStatisticalBlock.timestamp.getTime();
-    const addressTvlMap = await this.getAddressTvlMap(currentStatisticalBlock.number, blockTs, tokenPriceMap);
+    const [addressMap, addressTvlMap] = await this.getAddressTvlMap(currentStatisticalBlock.number, blockTs, tokenPriceMap);
     this.logger.log(`Address tvl map size: ${addressTvlMap.size}`);
-    let addresses: Array<string> = [];
-    for (const key of addressTvlMap.keys()) {
-      const [address, _] = key.split("-");
-      if (!addresses.includes(address)) {
-        addresses.push(address);
-      }
-    }
+    let addresses = [...addressMap.keys()]
+
     this.logger.log(`Address list size: ${addresses.length}`);
     // get all first deposit time
     const addressFirstDepositList = await this.addressFirstDepositRepository.getAllAddressesFirstDeposits(addresses);
@@ -194,12 +189,13 @@ export class TvlPointService extends Worker {
     blockNumber: number,
     blockTs: number,
     tokenPriceMap: Map<string, BigNumber>
-  ): Promise<Map<string, BlockAddressTvl>> {
+  ): Promise<[Map<string, boolean>, Map<string, BlockAddressTvl>]> {
     // If the score for this block height already exists,
     // it should not be calculated again
     const alreadyCalculatedPointsKey = await this.blockAddressPointOfLpRepository.getBlockAddressPointKeyByBlock(blockNumber)
 
     const addressTvlMap: Map<string, BlockAddressTvl> = new Map();
+    const addressMap: Map<string, boolean> = new Map()
     const blockNumbers = [blockNumber];
     const balanceList = await this.balanceOfLpRepository.getAllByBlocks(blockNumbers);
     this.logger.log(`The all address list length: ${balanceList.length}`);
@@ -208,6 +204,10 @@ export class TvlPointService extends Worker {
       const balance = balanceList[index];
       const address = hexTransformer.from(balance.address);
       const pairAddress = hexTransformer.from(balance.pairAddress);
+      if (!addressMap.has(address)) {
+        addressMap.set(address, true)
+      }
+
       const key = `${address}-${pairAddress}`;
       if (balanceMap.has(key)) {
         balanceMap.get(key).push(balance);
@@ -224,7 +224,7 @@ export class TvlPointService extends Worker {
       }
       addressTvlMap.set(key, addressTvl);
     }
-    return addressTvlMap;
+    return [addressMap, addressTvlMap];
   }
 
   // find the latest multiplier before the block timestamp

--- a/src/points/tvlPoint.service.ts
+++ b/src/points/tvlPoint.service.ts
@@ -195,6 +195,10 @@ export class TvlPointService extends Worker {
     blockTs: number,
     tokenPriceMap: Map<string, BigNumber>
   ): Promise<Map<string, BlockAddressTvl>> {
+    // If the score for this block height already exists,
+    // it should not be calculated again
+    const pointAddresses = await this.blockAddressPointOfLpRepository.getBlockAddressPointOfLpByBlock(blockNumber) //
+
     const addressTvlMap: Map<string, BlockAddressTvl> = new Map();
     const blockNumbers = [blockNumber];
     const balanceList = await this.balanceOfLpRepository.getAllByBlocks(blockNumbers);
@@ -208,7 +212,9 @@ export class TvlPointService extends Worker {
       if (balanceMap.has(key)) {
         balanceMap.get(key).push(balance);
       } else {
-        balanceMap.set(key, [balance]);
+        if (!pointAddresses.includes(address)) {
+          balanceMap.set(key, [balance]);
+        }
       }
     }
     for (const [key, value] of balanceMap) {

--- a/src/points/tvlPoint.service.ts
+++ b/src/points/tvlPoint.service.ts
@@ -204,9 +204,6 @@ export class TvlPointService extends Worker {
       const balance = balanceList[index];
       const address = hexTransformer.from(balance.address);
       const pairAddress = hexTransformer.from(balance.pairAddress);
-      if (!addressMap.has(address)) {
-        addressMap.set(address, true)
-      }
 
       const key = `${address}-${pairAddress}`;
       if (balanceMap.has(key)) {
@@ -221,6 +218,10 @@ export class TvlPointService extends Worker {
       const addressTvl = await this.calculateAddressTvl(value, tokenPriceMap, blockTs);
       if (addressTvl.holdBasePoint.isZero()) {
         continue;
+      }
+      const [address] = key.split('-')
+      if (!addressMap.has(address)) {
+        addressMap.set(address, true)
       }
       addressTvlMap.set(key, addressTvl);
     }

--- a/src/repositories/blockAddressPointOfLp.repository.ts
+++ b/src/repositories/blockAddressPointOfLp.repository.ts
@@ -10,6 +10,20 @@ export class BlockAddressPointOfLpRepository extends BaseRepository<BlockAddress
     super(BlockAddressPointOfLp, unitOfWork);
   }
 
+  public async getBlockAddressPointOfLpByBlock(
+    block: number
+  ): Promise<string[]> {
+    const transactionManager = this.unitOfWork.getTransactionManager();
+    const result = await transactionManager.transaction(async (entityManager) => {
+      const blockAddressPoints = await entityManager.getRepository(BlockAddressPointOfLp).find({
+        where: { blockNumber: block },
+        select: ["address"]
+      })
+      return blockAddressPoints.map(point => point.address);
+    });
+    return result;
+  }
+
   public async upsertUserPoints(
     receiverBlocBlockAddressPoint: QueryDeepPartialEntity<BlockAddressPointOfLp>,
     receiverAddressPoint: QueryDeepPartialEntity<PointsOfLp>

--- a/src/repositories/blockAddressPointOfLp.repository.ts
+++ b/src/repositories/blockAddressPointOfLp.repository.ts
@@ -10,16 +10,16 @@ export class BlockAddressPointOfLpRepository extends BaseRepository<BlockAddress
     super(BlockAddressPointOfLp, unitOfWork);
   }
 
-  public async getBlockAddressPointOfLpByBlock(
+  public async getBlockAddressPointKeyByBlock(
     block: number
   ): Promise<string[]> {
     const transactionManager = this.unitOfWork.getTransactionManager();
     const result = await transactionManager.transaction(async (entityManager) => {
       const blockAddressPoints = await entityManager.getRepository(BlockAddressPointOfLp).find({
         where: { blockNumber: block },
-        select: ["address"]
+        select: ["address", "pairAddress"]
       })
-      return blockAddressPoints.map(point => point.address);
+      return blockAddressPoints.map(point => `${point.address}-${point.pairAddress}`);
     });
     return result;
   }


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE/default_template.md -->

## Description
<!-- Please include a summary of the changes and the related issue. -->
- fix transactionDataBlockNumber cache value
- when compensating points, filter out addresses that have already had their scores calculated
## Type of change

- \[x\] Bug fix
- \[ \] New feature
- \[ \] Breaking change
- \[ \] Documentation update
