### PR TITLE
interport: add tx/volume tracking

### DIFF
--- a/src/adapters/interport/execution/src/index.ts
+++ b/src/adapters/interport/execution/src/index.ts
@@ -1,10 +1,14 @@
-import { UserTVLData } from './sdk/types';
+import { UserTransfersData, UserTVLData } from './sdk/types';
 import {
-  getUserPositionsAtBlock,
+  getUserPositionsAtBlock, getUserTransactionsData
 } from './sdk/lib';
 
 export const getUserTVLData = async (blockNumber: number): Promise<UserTVLData[]> => {
   const res: UserTVLData[] = await getUserPositionsAtBlock(blockNumber);
 
   return res.map(item => ({ ...item, blockNumber: blockNumber }));
+};
+
+export const getUserTransactionData = (startBlock: number, endBlock: number): Promise<UserTransfersData[]> => {
+  return getUserTransactionsData(startBlock, endBlock);
 };

--- a/src/adapters/interport/execution/src/sdk/types.ts
+++ b/src/adapters/interport/execution/src/sdk/types.ts
@@ -1,5 +1,21 @@
 export type Address = string;
 
+export type UserTransfersData = {
+    timestamp: number
+    userAddress: string
+    contractAddress: string
+    tokenAddress: string
+    decimals: number
+    quantity: bigint
+    txHash: string
+    nonce: string
+    blockNumber: number
+}
+
+export type UserTransfers = {
+    transferEvents: UserTransfersData[];
+}
+
 export type UserTVLData = {
     userAddress: Address;
     tokenAddress: Address;
@@ -22,8 +38,8 @@ export type UserStakes = {
     userStakes: StakeData[];
 }
 
-export type Response = {
-    data: UserStakes;
+export type Response<T> = {
+    data: T;
 }
 
 export type Call = {

--- a/src/adapters/interport/subgraph/abis/ActionExecutor.json
+++ b/src/adapters/interport/subgraph/abis/ActionExecutor.json
@@ -1,0 +1,1387 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract IRegistry",
+        "name": "_registry",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IVariableBalanceRecords",
+        "name": "_variableBalanceRecords",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_actionIdOffset",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_managers",
+        "type": "address[]"
+      },
+      {
+        "internalType": "bool",
+        "name": "_addOwnerToManagers",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "CallerGuardError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "GatewayNotSetError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ListSizeLimitError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MessageFeeError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NativeTokenValueError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "NonContractAddressError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyGatewayError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyManagerError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlySelfError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReservedTokenError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "RouterNotSetError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SafeApproveError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SafeTransferError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SafeTransferFromError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SafeTransferNativeError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SameChainIdError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SameTokenError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SwapAmountMaxError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SwapAmountMinError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SwapError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TargetSwapInfoError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TokenMintError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VaultNotSetError",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "actionId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "fromToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "toToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fromAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "toAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "toTokenFee",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "ActionLocal",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "actionId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "targetChainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sourceSender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "targetRecipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "gatewayType",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "sourceToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "targetToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "ActionSource",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "actionId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "sourceChainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bool",
+        "name": "isSuccess",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "ActionTarget",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "RenounceManagerRole",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "enum CallerGuard.CallerGuardMode",
+        "name": "callerGuardMode",
+        "type": "uint8"
+      }
+    ],
+    "name": "SetCallerGuardMode",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "contractAddress",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bool",
+        "name": "isListed",
+        "type": "bool"
+      }
+    ],
+    "name": "SetListedCallerGuardContract",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bool",
+        "name": "value",
+        "type": "bool"
+      }
+    ],
+    "name": "SetManager",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "registryAddress",
+        "type": "address"
+      }
+    ],
+    "name": "SetRegistry",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recordsAddress",
+        "type": "address"
+      }
+    ],
+    "name": "SetVariableBalanceRecords",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "actionId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bool",
+        "name": "isLocal",
+        "type": "bool"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "routerType",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "fromTokenAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "toTokenAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fromAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "resultAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "SourceProcessed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "actionId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "routerType",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "fromTokenAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "toTokenAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fromAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "resultAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "TargetProcessed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "actionId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "vaultType",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "VariableBalanceAllocated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "SYSTEM_VERSION_ID",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_fromAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isForward",
+        "type": "bool"
+      }
+    ],
+    "name": "calculateLocalAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "result",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_vaultType",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_fromChainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_toChainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_fromAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isForward",
+        "type": "bool"
+      }
+    ],
+    "name": "calculateVaultAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "result",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "callerGuardMode",
+    "outputs": [
+      {
+        "internalType": "enum CallerGuard.CallerGuardMode",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_vaultType",
+        "type": "uint256"
+      }
+    ],
+    "name": "claimVariableToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_tokenAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "cleanup",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_vaultType",
+        "type": "uint256"
+      }
+    ],
+    "name": "convertVariableBalanceToVaultAsset",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "gatewayType",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "vaultType",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "sourceTokenAddress",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "fromAmount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "routerType",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "routerData",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct IActionDataStructures.SwapInfo",
+            "name": "sourceSwapInfo",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "targetChainId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "targetTokenAddress",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "fromAmount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "routerType",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "routerData",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct IActionDataStructures.SwapInfo[]",
+            "name": "targetSwapInfoOptions",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "address",
+            "name": "targetRecipient",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "gatewaySettings",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IActionDataStructures.Action",
+        "name": "_action",
+        "type": "tuple"
+      }
+    ],
+    "name": "execute",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "actionId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "fromTokenAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "toTokenAddress",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "fromAmount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "routerType",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "routerData",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct IActionDataStructures.SwapInfo",
+            "name": "swapInfo",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct IActionDataStructures.LocalAction",
+        "name": "_localAction",
+        "type": "tuple"
+      }
+    ],
+    "name": "executeLocal",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "actionId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "fullListedCallerGuardContractList",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "fullManagerList",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_messageSourceChainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_payloadData",
+        "type": "bytes"
+      }
+    ],
+    "name": "handleExecutionPayload",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "isListedCallerGuardContract",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "isManager",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_tokenAddress",
+        "type": "address"
+      }
+    ],
+    "name": "isReservedToken",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "listedCallerGuardContractCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "listedCallerGuardContractIndexMap",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isSet",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "listedCallerGuardContractList",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "managerCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_gatewayType",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_targetChainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "_targetRouterDataOptions",
+        "type": "bytes[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_gatewaySettings",
+        "type": "bytes"
+      }
+    ],
+    "name": "messageFeeEstimate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "registry",
+    "outputs": [
+      {
+        "internalType": "contract IRegistry",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceManagerRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "router",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "routerTransfer",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "vault",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "gasReserve",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct ISettings.TargetSettings",
+        "name": "_settings",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "actionId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "sourceSender",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "vaultType",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "targetTokenAddress",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "fromAmount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "routerType",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "routerData",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct IActionDataStructures.SwapInfo",
+            "name": "targetSwapInfo",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "targetRecipient",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct IActionDataStructures.TargetMessage",
+        "name": "_targetMessage",
+        "type": "tuple"
+      }
+    ],
+    "name": "selfCallTarget",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum CallerGuard.CallerGuardMode",
+        "name": "_callerGuardMode",
+        "type": "uint8"
+      }
+    ],
+    "name": "setCallerGuardMode",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "flag",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct AccountToFlag[]",
+        "name": "_items",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "setListedCallerGuardContracts",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_value",
+        "type": "bool"
+      }
+    ],
+    "name": "setManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IRegistry",
+        "name": "_registry",
+        "type": "address"
+      }
+    ],
+    "name": "setRegistry",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_tokenAddress",
+        "type": "address"
+      }
+    ],
+    "name": "tokenBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_vaultType",
+        "type": "uint256"
+      }
+    ],
+    "name": "variableBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "variableBalanceRecords",
+    "outputs": [
+      {
+        "internalType": "contract IVariableBalanceRecords",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/src/adapters/interport/subgraph/abis/ERC20.json
+++ b/src/adapters/interport/subgraph/abis/ERC20.json
@@ -1,0 +1,117 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_spender", "type": "address" },
+      { "name": "_value", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_from", "type": "address" },
+      { "name": "_to", "type": "address" },
+      { "name": "_value", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "name": "", "type": "uint8" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_owner", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "name": "balance", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_to", "type": "address" },
+      { "name": "_value", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "_owner", "type": "address" },
+      { "name": "_spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "payable": true, "stateMutability": "payable", "type": "fallback" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "owner", "type": "address" },
+      { "indexed": true, "name": "spender", "type": "address" },
+      { "indexed": false, "name": "value", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "from", "type": "address" },
+      { "indexed": true, "name": "to", "type": "address" },
+      { "indexed": false, "name": "value", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  }
+]

--- a/src/adapters/interport/subgraph/schema.graphql
+++ b/src/adapters/interport/subgraph/schema.graphql
@@ -6,3 +6,17 @@ type UserStake @entity {
   timestamp: BigInt!
   blocknumber: BigInt!
 }
+
+type TransferEvent @entity {
+  id: ID!
+  timestamp: BigInt!
+  userAddress: Bytes!
+  contractAddress: Bytes!
+  tokenAddress: Bytes!
+  quantity: BigInt!
+  txHash: Bytes!
+  nonce: String!
+  blockNumber: BigInt!
+  price: BigDecimal!
+  decimals:  Int!
+}

--- a/src/adapters/interport/subgraph/src/constants/index.ts
+++ b/src/adapters/interport/subgraph/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './tokens';

--- a/src/adapters/interport/subgraph/src/constants/tokens.ts
+++ b/src/adapters/interport/subgraph/src/constants/tokens.ts
@@ -1,0 +1,18 @@
+export class IToken {
+  decimals: u8;
+  address: string;
+  symbol: string;
+
+  constructor(decimals: u8, address: string, symbol: string) {
+    this.decimals = decimals;
+    this.address = address;
+    this.symbol = symbol;
+  }
+}
+
+export const STABLE_POOL_TOKENS: IToken[] = [
+  new IToken(6, "0x2f8a25ac62179b31d62d7f80884ae57464699059", "USDT"),
+  new IToken(6, "0x1a1a3b2ff016332e866787b311fcb63928464509", "USDC"),
+];
+
+export const NATIVE_ADDRESS = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'

--- a/src/adapters/interport/subgraph/src/mapping.ts
+++ b/src/adapters/interport/subgraph/src/mapping.ts
@@ -1,7 +1,11 @@
-import { Staked } from '../generated/StablecoinFarm/StablecoinFarm'
-import { UserStake } from '../generated/schema'
+import { Staked } from '../generated/StablecoinFarm/StablecoinFarm';
+import { TransferEvent, UserStake } from '../generated/schema';
+import { TargetProcessed } from '../generated/ActionExecutor/ActionExecutor';
+import { IToken, NATIVE_ADDRESS, STABLE_POOL_TOKENS } from './constants';
+import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts';
+import { ERC20 } from '../generated/ActionExecutor/ERC20';
 
-export function handleStaked(event: Staked): void {
+export function handleStaked (event: Staked): void {
   const id = event.transaction.hash.toHex() + '-' + event.logIndex.toString();
   let stake = new UserStake(id);
 
@@ -12,4 +16,75 @@ export function handleStaked(event: Staked): void {
   stake.blocknumber = event.block.number;
 
   stake.save();
+}
+
+export function handleActionTarget (event: TargetProcessed): void {
+  let entity = new TransferEvent(event.transaction.hash.toHex() + '-' + event.logIndex.toString());
+
+  const toTokenAddress = event.params.toTokenAddress.toHex().toLowerCase();
+
+  let decimalPrice = BigDecimal.zero();
+  let toTokenDecimals = getTokenDecimals(toTokenAddress);
+
+  const fromTokenAddress = event.params.fromTokenAddress.toHex().toLowerCase();
+  const fromTokenData = getTokenInfo(fromTokenAddress);
+
+  if (fromTokenData && toTokenDecimals) {
+    const fromAmount = new BigDecimal(event.params.fromAmount);
+    const tokenDecimals = new BigDecimal(BigInt.fromI32(10).pow(fromTokenData.decimals));
+    const sumInUsd = fromAmount.div(tokenDecimals);
+
+    decimalPrice = new BigDecimal(
+      BigInt.fromI32(10).pow(toTokenDecimals)
+    )
+      .times(sumInUsd)
+      .div(new BigDecimal(event.params.resultAmount));
+  }
+
+  entity.timestamp = event.block.timestamp;
+  entity.userAddress = event.params.recipient;
+  entity.contractAddress = event.address;
+  entity.tokenAddress = event.params.toTokenAddress;
+  entity.quantity = event.params.resultAmount;
+  entity.txHash = event.transaction.hash;
+  entity.nonce = event.logIndex.toString();
+  entity.blockNumber = event.block.number;
+  entity.price = decimalPrice.truncate(2);
+  entity.decimals = toTokenDecimals;
+
+  entity.save();
+}
+
+export function getTokenInfo (tokenAddress: string): IToken | null {
+  let tokenInfo: IToken | null = null;
+
+  for (let i = 0; i < STABLE_POOL_TOKENS.length; i++) {
+    if (STABLE_POOL_TOKENS[i].address == tokenAddress) {
+      tokenInfo = STABLE_POOL_TOKENS[i];
+      break;
+    }
+  }
+
+  return tokenInfo;
+}
+
+function getTokenDecimals (address: string): u8 {
+  if(isNative(address)) {
+    return 18;
+  }
+
+  let token = ERC20.bind(Address.fromString(address));
+
+
+  let decimals = token.try_decimals();
+
+  if (decimals.reverted) {
+    return 0;
+  }
+
+  return u8(decimals.value);
+}
+
+function isNative (address: string): boolean {
+  return address.toLowerCase() == NATIVE_ADDRESS;
 }

--- a/src/adapters/interport/subgraph/subgraph.yaml
+++ b/src/adapters/interport/subgraph/subgraph.yaml
@@ -23,3 +23,26 @@ dataSources:
       eventHandlers:
         - event: Staked(indexed address,indexed uint256,uint256)
           handler: handleStaked
+
+  - kind: ethereum/contract
+    name: ActionExecutor
+    network: zklink-nova
+    source:
+      address: '0x5c8F53c3647a06c88416EF0BD8e2bfBaa1e5dEeE'
+      abi: ActionExecutor
+      startBlock: 818707
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/mapping.ts
+      entities:
+        - TransferEvent
+      abis:
+        - name: ActionExecutor
+          file: ./abis/ActionExecutor.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+      eventHandlers:
+        - event: TargetProcessed(indexed uint256,indexed address,uint256,address,address,uint256,uint256)
+          handler: handleActionTarget

--- a/src/config/projectTxBooster.ts
+++ b/src/config/projectTxBooster.ts
@@ -5,6 +5,7 @@ export default {
     agx: 1 / 100,
     wagmi: 1 / 200,
     zkdx: 1 / 200,
+    interport: 1 / 200,
   },
   txNum: {
     allspark: 1 / 1,


### PR DESCRIPTION
**NOTE**

### Please enable "Allow edits by maintainers" while putting up the PR.
____

## Type of change
- [x] New adapters
- [ ] Adapter-related bug fix
<!-- Description: description of the bug and fix -->
Description:

___

#### For Volume/Transaction Points Calculation:

1. Dapp Description:
   Interport Finance is a DeFi platform enabling cross-chain and single-chain swaps with the best trading rates, achieved through Meta DEX aggregation. By utilizing cross-chain messaging, Interport eliminates the need for traditional bridges, streamlining the process for asset swaps between different blockchains

2. User Points Calculation Criteria:
   If the address specified as the recipient in this event is involved, it indicates that a cross-chain transaction was executed to transfer funds to this address. As a result, this address qualifies to earn points.

3. Solidity Contract Signature Involved in Transactions:
   TargetProcessed(indexed uint256,indexed address,uint256,address,address,uint256,uint256)

4. Conditions for User Points Calculation:
   The recipient address and resultAmount (which represents the quantity of the transferred asset) are extracted from this event. We then calculate the price of the asset based on the amount used to complete the swap or bridge (which is always either USDC or USDT). The points are determined based on this calculated value, corresponding to the transferred amount.

5. Quantity Calculation Rule:
   The quantity is calculated based on the TargetProcessed event, specifically from the resultAmount value, which is a uint256

